### PR TITLE
added hotkeys to increase or decrease playback speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ Status: maintained
 
 [![GoDoc](https://godoc.org/github.com/Linus4/csgoverview?status.svg)](https://godoc.org/github.com/Linus4/csgoverview) [![Go Report Card](https://goreportcard.com/badge/github.com/linus4/csgoverview)](https://goreportcard.com/report/github.com/linus4/csgoverview)  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Linus4/csgoverview/blob/master/LICENSE) [![Paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.me/linuswbr)
 
-Check out the [Roadmap](https://github.com/Linus4/csgoverview/projects/1) where
-I keep track of ideas and todos.
-
 ## Chat
 
 I created a chatroom on Gitter so we have a place to talk about suggestions, problems and other questions.
@@ -33,14 +30,16 @@ I created a chatroom on Gitter so we have a place to talk about suggestions, pro
 * D -> 10 s forwards
 * w -> hold to speed up 5 x
 * s -> hold to slow down to 0.5 x
+* W -> increase playback speed by 0.25
+* S -> decrease playback speed by 0.25
 * q -> round backwards
 * e -> round forwards
 * Q -> to start of previous half
 * E -> to start of next half
 * space -> toggle pause
 * mouse wheel -> scroll 1 second forwards/backwards
-* C -> switch to alternate overview image (normal / lower)
-* H -> hide player names on map
+* c -> switch to alternate overview image (normal / lower)
+* h -> hide player names on map
 * 0-9 -> copy players position and view angle to clipboard
 
 ## Tool recommendations

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ I created a chatroom on Gitter so we have a place to talk about suggestions, pro
 * d -> 5 s forwards
 * A -> 10 s backwards
 * D -> 10 s forwards
-* w -> hold to speed up 5 x
-* s -> hold to slow down to 0.5 x
-* W -> increase playback speed by 0.25
-* S -> decrease playback speed by 0.25
+* w -> increase playback speed
+* s -> decrease playback speed
+* r -> reset playback speed to x 1
+* W -> hold to speed up 5 x
+* S -> hold to slow down to 0.5 x
 * q -> round backwards
 * e -> round forwards
 * Q -> to start of previous half

--- a/app.go
+++ b/app.go
@@ -395,14 +395,32 @@ func handleKeyboardEvents(eventT *sdl.KeyboardEvent, window *sdl.Window, match *
 	}
 
 	if eventT.Type == sdl.KEYDOWN && !isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_w {
-		if staticPlaybackSpeedModifier <= 1.75 {
-			staticPlaybackSpeedModifier += 0.25
+		switch staticPlaybackSpeedModifier {
+		case 0.25:
+			staticPlaybackSpeedModifier = 0.5
+		case 0.5:
+			staticPlaybackSpeedModifier = 1
+		case 1:
+			staticPlaybackSpeedModifier = 1.25
+		case 1.25:
+			staticPlaybackSpeedModifier = 1.5
+		case 1.5:
+			staticPlaybackSpeedModifier = 2
 		}
 	}
 
 	if eventT.Type == sdl.KEYDOWN && !isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_s {
-		if staticPlaybackSpeedModifier >= 0.5 {
-			staticPlaybackSpeedModifier -= 0.25
+		switch staticPlaybackSpeedModifier {
+		case 0.5:
+			staticPlaybackSpeedModifier = 0.25
+		case 1:
+			staticPlaybackSpeedModifier = 0.5
+		case 1.25:
+			staticPlaybackSpeedModifier = 1
+		case 1.5:
+			staticPlaybackSpeedModifier = 1.25
+		case 2:
+			staticPlaybackSpeedModifier = 1.5
 		}
 	}
 

--- a/app.go
+++ b/app.go
@@ -228,11 +228,11 @@ func run(c *Config) error {
 		frameDuration := float64(time.Since(frameStart) / 1000000)
 		keyboardState := sdl.GetKeyboardState()
 		if keyboardState[sdl.GetScancodeFromKey(sdl.K_w)] != 0 &&
-			keyboardState[sdl.GetScancodeFromKey(sdl.K_LSHIFT)] == 0 {
+			keyboardState[sdl.GetScancodeFromKey(sdl.K_LSHIFT)] != 0 {
 			playbackSpeedModifier = 5
 		}
 		if keyboardState[sdl.GetScancodeFromKey(sdl.K_s)] != 0 &&
-			keyboardState[sdl.GetScancodeFromKey(sdl.K_LSHIFT)] == 0 {
+			keyboardState[sdl.GetScancodeFromKey(sdl.K_LSHIFT)] != 0 {
 			playbackSpeedModifier = 0.5
 		}
 		delay := (1/(playbackSpeedModifier*staticPlaybackSpeedModifier))*(1000/float64(match.FrameRateRounded)) - frameDuration
@@ -393,12 +393,12 @@ func handleKeyboardEvents(eventT *sdl.KeyboardEvent, window *sdl.Window, match *
 	if eventT.Type == sdl.KEYDOWN && eventT.Keysym.Sym == sdl.K_9 {
 		copyPositionToClipboard(8, match)
 	}
-	if eventT.Type == sdl.KEYDOWN && isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_w {
+	if eventT.Type == sdl.KEYDOWN && !isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_w {
 		if staticPlaybackSpeedModifier <= 1.75 {
 			staticPlaybackSpeedModifier += 0.25
 		}
 	}
-	if eventT.Type == sdl.KEYDOWN && isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_s {
+	if eventT.Type == sdl.KEYDOWN && !isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_s {
 		if staticPlaybackSpeedModifier >= 0.5 {
 			staticPlaybackSpeedModifier -= 0.25
 		}

--- a/app.go
+++ b/app.go
@@ -393,15 +393,21 @@ func handleKeyboardEvents(eventT *sdl.KeyboardEvent, window *sdl.Window, match *
 	if eventT.Type == sdl.KEYDOWN && eventT.Keysym.Sym == sdl.K_9 {
 		copyPositionToClipboard(8, match)
 	}
+
 	if eventT.Type == sdl.KEYDOWN && !isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_w {
 		if staticPlaybackSpeedModifier <= 1.75 {
 			staticPlaybackSpeedModifier += 0.25
 		}
 	}
+
 	if eventT.Type == sdl.KEYDOWN && !isShiftPressed(eventT) && eventT.Keysym.Sym == sdl.K_s {
 		if staticPlaybackSpeedModifier >= 0.5 {
 			staticPlaybackSpeedModifier -= 0.25
 		}
+	}
+
+	if eventT.Type == sdl.KEYDOWN && eventT.Keysym.Sym == sdl.K_r {
+		staticPlaybackSpeedModifier = 1
 	}
 	/*
 		if eventT.Type == sdl.KEYDOWN && eventT.Keysym.Sym == sdl.K_p {

--- a/draw.go
+++ b/draw.go
@@ -298,6 +298,7 @@ func drawInfobars(renderer *sdl.Renderer, match *match.Match, font *ttf.Font) {
 	drawInfobar(renderer, ts, mapXOffset+mapOverviewWidth, mapYOffset, colorTerror, font)
 	drawKillfeed(renderer, match.Killfeed[curFrame], mapXOffset+mapOverviewWidth, mapYOffset+600, font)
 	drawTimer(renderer, match.States[curFrame].Timer, 0, mapYOffset+600, font)
+	drawPlaybackSpeedModifier(renderer, 5, mapYOffset+630, font)
 }
 
 func drawInfobar(renderer *sdl.Renderer, players []common.Player, x, y int32, color sdl.Color, font *ttf.Font) {
@@ -440,6 +441,11 @@ func drawShot(renderer *sdl.Renderer, shot *common.Shot, match *match.Match) {
 	targetY := int32(scaledYInt) + int32(math.Sin(viewAngleRadian)*shotLength/float64(match.MapScale))
 
 	gfx.AALineColor(renderer, scaledXInt, scaledYInt, targetX, targetY, color)
+}
+
+func drawPlaybackSpeedModifier(renderer *sdl.Renderer, x, y int32, font *ttf.Font) {
+	str := fmt.Sprintf("Playback-Speed: x %v", staticPlaybackSpeedModifier*playbackSpeedModifier)
+	drawString(renderer, str, colorDarkWhite, x, y, font)
 }
 
 func cropStringToN(s string, n int) string {


### PR DESCRIPTION
fixes #18 

shift + w or s to increase or decrease playback speed by 0.25 (min: 0.25, max: 2)

* Does it *need* a hotkey to return to x 1 playback speed? If so, which one?
* Are the speed modifiers okay? (0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2) Or should I leave some out? Feels like 0.75 and 1.75 are useless, but would it make the program that much better to use if I removed those modifiers?
* Does it need modifiers > 2?
* In order to display playback speed modifier:
  - Timer + " x " + Modifier (e.g. `1:25 x 2`)
  - or Timer \n "Playback-Speed: x " + Modifier (current)