### PR TITLE
Added headshot to kill feed

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -56,6 +56,7 @@ type Kill struct {
 	VictimName string
 	VictimTeam demoinfo.Team
 	Weapon     demoinfo.EquipmentType
+	Headshot   bool
 }
 
 // Timer contains the time remaining in the current phase of the round.

--- a/draw.go
+++ b/draw.go
@@ -20,6 +20,7 @@ const (
 	radiusSmoke       float64 = 25
 	killfeedHeight    int32   = 15
 	shotLength        float64 = 1000
+	headshotRune      rune    = '\u205c'
 )
 
 var (
@@ -417,7 +418,7 @@ func drawKillfeed(renderer *sdl.Renderer, killfeed []common.Kill, x, y int32, fo
 		weaponName := cropStringToN(kill.Weapon.String(), 10)
 		drawString(renderer, killerName, colorKiller, x+5, y+yOffset, font)
 		if kill.Headshot {
-			weaponName = weaponName + " \u205c"
+			weaponName = weaponName + " " + string(headshotRune)
 		}
 		drawString(renderer, weaponName, colorDarkWhite, x+112, y+yOffset, font)
 		drawString(renderer, victimName, colorVictim, x+222, y+yOffset, font)

--- a/draw.go
+++ b/draw.go
@@ -416,8 +416,11 @@ func drawKillfeed(renderer *sdl.Renderer, killfeed []common.Kill, x, y int32, fo
 		victimName := cropStringToN(kill.VictimName, 10)
 		weaponName := cropStringToN(kill.Weapon.String(), 10)
 		drawString(renderer, killerName, colorKiller, x+5, y+yOffset, font)
-		drawString(renderer, weaponName, colorDarkWhite, x+110, y+yOffset, font)
-		drawString(renderer, victimName, colorVictim, x+200, y+yOffset, font)
+		if kill.Headshot {
+			weaponName = weaponName + " \u205c"
+		}
+		drawString(renderer, weaponName, colorDarkWhite, x+112, y+yOffset, font)
+		drawString(renderer, victimName, colorVictim, x+222, y+yOffset, font)
 		yOffset += killfeedHeight
 	}
 }

--- a/match/match.go
+++ b/match/match.go
@@ -350,6 +350,7 @@ func registerEventHandlers(parser dem.Parser, match *Match) {
 			VictimName: victimName,
 			VictimTeam: victimTeam,
 			Weapon:     e.Weapon.Type,
+			Headshot:   e.IsHeadshot,
 		}
 
 		for i := 0; i < match.FrameRateRounded*killfeedLifetime; i++ {


### PR DESCRIPTION
Continuing work from https://github.com/Linus4/csgoverview/pull/2 since it looks to have been abandoned.

## Description
Added a headshot icon to the kill feed. Using `\u205c` from `DejaVuSans` to represent it.

## How does it look:
<img width="184" alt="Screenshot 2021-02-23 at 17 39 58" src="https://user-images.githubusercontent.com/5747313/108876177-3e29c580-75fe-11eb-9991-dd5b7f156edc.png">

## Headshot icon being used:
<img width="260" alt="Screenshot 2021-02-23 at 17 33 02" src="https://user-images.githubusercontent.com/5747313/108875546-98765680-75fd-11eb-8623-01769d05f983.png">