### PR TITLE
Add playback icon

### DIFF
--- a/app.go
+++ b/app.go
@@ -77,7 +77,7 @@ type app struct {
 	match               *match.Match
 	config              *Config
 
-	lastDraw                    time.Time
+	lastDrawnAt                 time.Time
 	isPaused                    bool
 	curFrame                    int
 	isOnNormalElevation         bool
@@ -203,7 +203,7 @@ func run(c *Config) error {
 		font:                        font,
 		match:                       match,
 		config:                      c,
-		lastDraw:                    time.Now().UTC(),
+		lastDrawnAt:                 time.Now().UTC(),
 		isPaused:                    false,
 		curFrame:                    0,
 		isOnNormalElevation:         true,
@@ -525,7 +525,7 @@ func (app *app) updateGraphics() {
 	m := app.match
 	app.renderer.SetDrawColor(10, 10, 10, 255)
 	app.renderer.Clear()
-	app.lastDraw = time.Now().UTC()
+	app.lastDrawnAt = time.Now().UTC()
 
 	app.drawInfobars()
 	app.renderer.Copy(app.mapTexture, nil, app.mapRect)

--- a/app.go
+++ b/app.go
@@ -77,6 +77,7 @@ type app struct {
 	match               *match.Match
 	config              *Config
 
+	lastDraw                    time.Time
 	isPaused                    bool
 	curFrame                    int
 	isOnNormalElevation         bool
@@ -202,6 +203,7 @@ func run(c *Config) error {
 		font:                        font,
 		match:                       match,
 		config:                      c,
+		lastDraw:                    time.Now().UTC(),
 		isPaused:                    false,
 		curFrame:                    0,
 		isOnNormalElevation:         true,
@@ -523,6 +525,7 @@ func (app *app) updateGraphics() {
 	m := app.match
 	app.renderer.SetDrawColor(10, 10, 10, 255)
 	app.renderer.Clear()
+	app.lastDraw = time.Now().UTC()
 
 	app.drawInfobars()
 	app.renderer.Copy(app.mapTexture, nil, app.mapRect)

--- a/draw.go
+++ b/draw.go
@@ -451,7 +451,7 @@ func (app *app) drawTimer(timer common.Timer, x, y int32) {
 		}
 		*/
 		var color sdl.Color
-		if app.lastDraw.Second()%2 == 0 && app.isPaused {
+		if app.lastDrawnAt.Second()%2 == 0 && app.isPaused {
 			color = colorDarkGrey
 		} else if timer.Phase == common.PhasePlanted {
 			color = colorBomb

--- a/draw.go
+++ b/draw.go
@@ -12,6 +12,11 @@ import (
 	"github.com/veandco/go-sdl2/sdl"
 )
 
+type PlaybackIcon struct {
+	Icon    rune
+	YOffset int32
+}
+
 const (
 	radiusPlayer      int32   = 10
 	radiusPlayerFloat float64 = float64(radiusPlayer)
@@ -40,6 +45,9 @@ var (
 	colorDarkGrey              = sdl.Color{125, 125, 125, 255}
 	colorFlashEffect           = sdl.Color{200, 200, 200, 180}
 	colorAwpShot               = sdl.Color{255, 50, 0, 255}
+
+	pauseIcon PlaybackIcon = PlaybackIcon{Icon: '\u1426', YOffset: 2}
+	playIcon  PlaybackIcon = PlaybackIcon{Icon: '\u2023', YOffset: 0}
 )
 
 func (app *app) drawPlayer(player *common.Player, index int) {
@@ -443,14 +451,23 @@ func (app *app) drawTimer(timer common.Timer, x, y int32) {
 		}
 		*/
 		var color sdl.Color
-		if timer.Phase == common.PhasePlanted {
+		if app.lastDraw.Second()%2 == 0 && app.isPaused {
+			color = colorDarkGrey
+		} else if timer.Phase == common.PhasePlanted {
 			color = colorBomb
 		} else if timer.Phase == common.PhaseRestart {
 			color = colorEqHE
 		} else {
 			color = colorDarkWhite
 		}
-		app.drawString(timeString, color, x+5, y)
+
+		playbackIcon := playIcon
+		if app.isPaused {
+			playbackIcon = pauseIcon
+		}
+
+		app.drawString(string(playbackIcon.Icon), color, x+5, y+playbackIcon.YOffset)
+		app.drawString(timeString, color, x+15, y)
 	}
 }
 


### PR DESCRIPTION
Using two different runes from the DejaVuSans font to achieve this.

1426 | 2023
:--:|:--:
![Screenshot 2021-04-07 at 14 17 17](https://user-images.githubusercontent.com/5747313/113865526-794a1780-97ac-11eb-9588-5141ca887623.png) | ![Screenshot 2021-04-07 at 14 17 46](https://user-images.githubusercontent.com/5747313/113865540-7cdd9e80-97ac-11eb-9efb-4b7369413803.png)

They have different "heights" ( the pause one starts a bit higher), so that is why there is a `YOffset` per rune.
Also added a small timer to know the last time we draw to the screen so we can create blinking feature (like the one introduced by this commit on the playback time).

![Screenshot 2021-06-02 at 10 51 48](https://user-images.githubusercontent.com/5747313/120454425-2ba8f000-c394-11eb-977b-8463ca2dce3d.png)
![Screenshot 2021-06-02 at 10 51 52](https://user-images.githubusercontent.com/5747313/120454443-2e0b4a00-c394-11eb-9c4d-cc1d45670f28.png)
![out1](https://user-images.githubusercontent.com/5747313/120986133-8e2b3300-c77c-11eb-99e0-468e0bc3d494.gif)

PS: The blinking wasn't part of the issue, I just got carried away. But we can remove it from this PR, of course.

This closes #38 
